### PR TITLE
Fixed TFM for key lookup benches

### DIFF
--- a/src/PrimitiveVsStronglyTypedKeyLookup/PrimitiveVsStronglyTypedKeyLookup.csproj
+++ b/src/PrimitiveVsStronglyTypedKeyLookup/PrimitiveVsStronglyTypedKeyLookup.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>StringVsStronglyTypedKeyLookup</RootNamespace>


### PR DESCRIPTION
~~Technically, nothing prevents running of some newer libraries using an older runtime, but there are no guaranties that it won't crash. In my case it crashes while running string benchmarks with the `linux-x64` runtime.~~